### PR TITLE
Update AnnotatingMarkupParser.java

### DIFF
--- a/src/main/java/pignlproc/markup/AnnotatingMarkupParser.java
+++ b/src/main/java/pignlproc/markup/AnnotatingMarkupParser.java
@@ -79,7 +79,7 @@ public class AnnotatingMarkupParser implements ITextConverter {
 
     public WikiModel makeWikiModel(String languageCode) {
         return new WikiModel(String.format(
-                "http:/%s.wikipedia.org/wiki/${image}", languageCode),
+                "http://%s.wikipedia.org/wiki/${image}", languageCode),
                 String.format("http://%s.wikipedia.org/wiki/${title}",
                         languageCode)) {
             @Override


### PR DESCRIPTION
Greetings,

I think there is a typo in Image Url template. Missing "/" in "http://". Am I right? If so, please consider pulling the fix.
Thank you!

Alfonso
